### PR TITLE
Bump maturin version to support building from source for Python versions not in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1.8"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
Resolves #23 

I'm not sure if this has wider consequences outside of supporting Rust 2024, but it works on my local with Python3.8.