### PR TITLE
Guard block chain walks and untrusted size fields in malformed files

### DIFF
--- a/src/mdfinfo.rs
+++ b/src/mdfinfo.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 use std::str;
 use std::sync::Arc;
 
+pub(crate) mod block_chain;
 pub mod mdfinfo3;
 
 /// Map from channel name to its position tuple: (master_name, dg_pos, cg_pos, rec_id, cn_pos, rec_pos).

--- a/src/mdfinfo/block_chain.rs
+++ b/src/mdfinfo/block_chain.rs
@@ -1,0 +1,50 @@
+//! Cycle guard for the singly linked block chains of MDF3 and MDF4 files.
+use log::warn;
+use std::collections::HashSet;
+
+/// Remembers the block offsets already walked in a linked list. MDF block chains
+/// are acyclic, so a repeated offset means the file is corrupted and following
+/// the link again would loop forever.
+#[derive(Debug)]
+pub(crate) struct BlockChain {
+    /// block type, only used for the warning message
+    kind: &'static str,
+    visited: HashSet<i64>,
+}
+
+impl BlockChain {
+    /// Starts tracking a chain of `kind` blocks ("FH", "DG", ...).
+    pub(crate) fn new(kind: &'static str) -> Self {
+        BlockChain {
+            kind,
+            visited: HashSet::new(),
+        }
+    }
+
+    /// Records `offset` and returns false if it was already walked.
+    pub(crate) fn visit(&mut self, offset: i64) -> bool {
+        if self.visited.insert(offset) {
+            true
+        } else {
+            warn!(
+                "{} block cycle detected at 0x{offset:x}, stopping chain walk",
+                self.kind
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_visit_detects_repeat() {
+        let mut chain = BlockChain::new("FH");
+        assert!(chain.visit(168));
+        assert!(chain.visit(224));
+        assert!(!chain.visit(168));
+        assert!(!chain.visit(224));
+    }
+}

--- a/src/mdfinfo/mdfinfo3.rs
+++ b/src/mdfinfo/mdfinfo3.rs
@@ -1,5 +1,5 @@
 //! Parsing of file metadata into MdfInfo3 struct
-use anyhow::{Context, Error, Result};
+use anyhow::{Context, Error, Result, bail};
 use arrow::array::{UInt8Builder, UInt16Builder, UInt32Builder};
 use binrw::{BinRead, BinReaderExt};
 use byteorder::{LittleEndian, ReadBytesExt};
@@ -16,6 +16,7 @@ use std::io::{Cursor, prelude::*};
 use crate::data_holder::channel_data::{ChannelData, data_type_init};
 use crate::data_holder::tensor_arrow::Order;
 use crate::mdfinfo::IdBlock;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::mdfinfo4::Endianness;
 
 use super::sym_buf_reader::SymBufReader;
@@ -712,6 +713,12 @@ pub fn parse_tx(
     rdr.seek_relative(target as i64 - position)
         .context("Could not reach position of TX block")?;
     let block_header: Blockheader3 = parse_block_header(rdr)?; // reads header
+    if block_header.hdr_len < 4 {
+        bail!(
+            "TX block at 0x{target:x} declares hdr_len={} < 4 (minimum header size)",
+            block_header.hdr_len
+        );
+    }
 
     // reads comment
     let mut comment_raw = vec![0; (block_header.hdr_len - 4) as usize];
@@ -815,7 +822,12 @@ pub fn parse_dg3(
         };
         dg.insert(dg_struct.block.dg_data, dg_struct);
         position = pos;
+        let mut chain = BlockChain::new("DG");
+        chain.visit(target as i64);
         while next_pointer > 0 {
+            if !chain.visit(next_pointer as i64) {
+                break;
+            }
             let block_start = next_pointer;
             let (block, pos) = parse_dg3_block(rdr, next_pointer, position)?;
             next_pointer = block.dg_dg_next;
@@ -960,7 +972,12 @@ pub fn parse_cg3(
         cg.insert(cg_struct.block.cg_record_id, cg_struct);
         n_cn += num_cn;
 
+        let mut chain = BlockChain::new("CG");
+        chain.visit(target as i64);
         while next_pointer != 0 {
+            if !chain.visit(next_pointer as i64) {
+                break;
+            }
             let (mut cg_struct, pos, num_cn) = parse_cg3_block(
                 rdr,
                 next_pointer,
@@ -1056,7 +1073,12 @@ pub fn parse_cn3(
         let mut next_pointer = cn_struct.block1.cn_cn_next;
         cn.insert(target, cn_struct);
 
+        let mut chain = BlockChain::new("CN");
+        chain.visit(target as i64);
         while next_pointer != 0 {
+            if !chain.visit(next_pointer as i64) {
+                break;
+            }
             let (cn_struct, pos) = parse_cn3_block(
                 rdr,
                 next_pointer,

--- a/src/mdfinfo/mdfinfo4/at_block.rs
+++ b/src/mdfinfo/mdfinfo4/at_block.rs
@@ -2,7 +2,7 @@
 //!
 //! Stores or references external files (e.g. calibration data, images) attached to the MDF file.
 //! Attachments can be embedded or external, with optional MD5 checksum verification.
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use binrw::{BinReaderExt, binrw};
 use log::warn;
 use md5::{Digest, Md5};
@@ -14,6 +14,7 @@ use std::io::{Cursor, Read};
 use super::block_header::{SharableBlocks, read_meta_data};
 use super::data_block::decompress_data;
 use super::metadata::BlockType;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::sym_buf_reader::SymBufReader;
 
 /// At4 Attachment block struct
@@ -150,6 +151,14 @@ fn parser_at4_block(
 
     // reads embedded if exists
     let data: Option<Vec<u8>> = if (block.at_flags & 0b1) > 0 {
+        let file_size = rdr.file_size().unwrap_or(u64::MAX);
+        let available = file_size.saturating_sub(position as u64);
+        if block.at_embedded_size > available {
+            bail!(
+                "attachment at 0x{target:x} declares {} embedded bytes but only {available} are left in the file",
+                block.at_embedded_size
+            );
+        }
         let mut embedded_data = vec![0u8; block.at_embedded_size as usize];
         rdr.read_exact(&mut embedded_data)
             .context("Could not parse At4Block embedded attachement")?;
@@ -202,7 +211,12 @@ pub fn parse_at4(
         let mut next_pointer = block.at_at_next;
         at.insert(target, (block, data));
 
+        let mut chain = BlockChain::new("AT");
+        chain.visit(target);
         while next_pointer > 0 {
+            if !chain.visit(next_pointer) {
+                break;
+            }
             let block_start = next_pointer;
             let (block, data, pos) = parser_at4_block(rdr, next_pointer, position)?;
             position = pos;

--- a/src/mdfinfo/mdfinfo4/cg_block.rs
+++ b/src/mdfinfo/mdfinfo4/cg_block.rs
@@ -16,6 +16,7 @@ use std::io::{Cursor, Read};
 use std::sync::Arc;
 
 use crate::data_holder::channel_data::ChannelData;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::sym_buf_reader::SymBufReader;
 
 use super::block_header::{
@@ -240,7 +241,11 @@ fn parse_sr4(
     }
 
     let mut next = target;
+    let mut chain = BlockChain::new("SR");
     while next > 0 {
+        if !chain.visit(next) {
+            break;
+        }
         // Read just the 16-byte header first to validate before allocating
         rdr.seek_relative(next - position)
             .context("Could not reach SR block header position")?;
@@ -251,6 +256,10 @@ fn parse_sr4(
             position = next + 16;
             break;
         }
+        let file_size = rdr.file_size().unwrap_or(u64::MAX);
+        header
+            .validate_len(file_size)
+            .context("SR block header length validation failed")?;
         // Now read the rest of the block
         let mut buf = vec![0u8; (header.hdr_len - 16) as usize];
         rdr.read_exact(&mut buf)
@@ -787,7 +796,12 @@ pub(super) fn parse_cg4(
         n_cg += 1;
         n_cn += num_cn;
 
+        let mut chain = BlockChain::new("CG");
+        chain.visit(target);
         while next_pointer != 0 {
+            if !chain.visit(next_pointer) {
+                break;
+            }
             let (mut cg_struct, pos, num_cn) =
                 parse_cg4_block(rdr, next_pointer, position, sharable, record_id_size)?;
             position = pos;

--- a/src/mdfinfo/mdfinfo4/ch_block.rs
+++ b/src/mdfinfo/mdfinfo4/ch_block.rs
@@ -2,7 +2,7 @@
 //!
 //! CHBLOCKs organize channels into a display hierarchy tree (groups, functions,
 //! input/output variables). The hierarchy is separate from the DG→CG→CN data structure.
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use binrw::{BinReaderExt, binrw};
 use std::collections::HashMap;
 use std::fmt::{self, Display};
@@ -10,6 +10,7 @@ use std::fs::File;
 
 use super::block_header::{SharableBlocks, parse_block_short, read_meta_data};
 use super::metadata::BlockType;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::sym_buf_reader::SymBufReader;
 
 /// CHBLOCK structure (MDF 4.2 spec, Table 15)
@@ -38,7 +39,7 @@ pub struct Ch4Block {
     /// link to MDBLOCK with a comment/description
     pub ch_md_comment: i64,
     /// list of elements in this hierarchy level
-    #[br(count = ch_links - 4)]
+    #[br(count = ch_links.saturating_sub(4))]
     pub ch_element: Vec<i64>,
 
     // data section
@@ -93,8 +94,19 @@ fn parser_ch4_block(
     target: i64,
     mut position: i64,
 ) -> Result<(Ch4Block, i64)> {
-    let (mut block, _header, pos) = parse_block_short(rdr, target, position)?;
+    let (mut block, header, pos) = parse_block_short(rdr, target, position)?;
     position = pos;
+    // ch_links comes from the file and sizes ch_element, so check it against the
+    // block length before binrw allocates the vector
+    let ch_links: u64 = block.read_le().context("Could not read ch_links")?;
+    block.set_position(0);
+    let max_links = header.hdr_len.saturating_sub(32) / 8;
+    if !(4..=max_links).contains(&ch_links) {
+        bail!(
+            "CH block at 0x{target:x} declares {ch_links} links, expected 4 to {max_links} for a {} byte block",
+            header.hdr_len
+        );
+    }
     let block: Ch4Block = block.read_le().context("Error parsing ch block")?;
 
     Ok((block, position))
@@ -105,11 +117,30 @@ pub fn parse_ch4(
     rdr: &mut SymBufReader<&File>,
     sharable: &mut SharableBlocks,
     target: i64,
-    mut position: i64,
+    position: i64,
 ) -> Result<(HashMap<i64, Ch4Block>, i64)> {
     let mut ch = HashMap::new();
+    // one tracker for the whole tree: it also stops a child link pointing back
+    // at an ancestor, which would otherwise recurse until the stack overflows
+    let mut chain = BlockChain::new("CH");
+    let position = parse_ch4_level(rdr, sharable, target, position, &mut ch, &mut chain)?;
+    Ok((ch, position))
+}
+
+/// parses one hierarchy level and, depth first, the levels below it
+fn parse_ch4_level(
+    rdr: &mut SymBufReader<&File>,
+    sharable: &mut SharableBlocks,
+    target: i64,
+    mut position: i64,
+    ch: &mut HashMap<i64, Ch4Block>,
+    chain: &mut BlockChain,
+) -> Result<i64> {
     let mut next_pointer = target;
     while next_pointer > 0 {
+        if !chain.visit(next_pointer) {
+            break;
+        }
         let block_start = next_pointer;
         let (block, pos) = parser_ch4_block(rdr, next_pointer, position)?;
         position = pos;
@@ -120,15 +151,13 @@ pub fn parse_ch4(
 
         // Traverse children
         if block.ch_ch_first > 0 {
-            let (children, pos) = parse_ch4(rdr, sharable, block.ch_ch_first, position)?;
-            position = pos;
-            ch.extend(children);
+            position = parse_ch4_level(rdr, sharable, block.ch_ch_first, position, ch, chain)?;
         }
 
         next_pointer = block.ch_ch_next;
         ch.insert(block_start, block);
     }
-    Ok((ch, position))
+    Ok(position)
 }
 
 #[cfg(test)]

--- a/src/mdfinfo/mdfinfo4/cn_block.rs
+++ b/src/mdfinfo/mdfinfo4/cn_block.rs
@@ -4,6 +4,7 @@
 //! bit position/length in the record, sync type, composition, source, and conversion.
 use crate::data_holder::channel_data::{ChannelData, data_type_init};
 use crate::data_holder::tensor_arrow::Order;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::sym_buf_reader::SymBufReader;
 use anyhow::{Context, Result};
 use arrow::array::{BooleanBufferBuilder, UInt8Builder, UInt16Builder, UInt32Builder};
@@ -573,7 +574,12 @@ pub(super) fn parse_cn4(
             cn.insert(first_rec_pos, cn_struct);
         }
 
+        let mut chain = BlockChain::new("CN");
+        chain.visit(target);
         while next_pointer != 0 {
+            if !chain.visit(next_pointer) {
+                break;
+            }
             let (cn_struct, pos, n_cns, cns) = parse_cn4_block(
                 rdr,
                 next_pointer,

--- a/src/mdfinfo/mdfinfo4/data_block.rs
+++ b/src/mdfinfo/mdfinfo4/data_block.rs
@@ -11,7 +11,7 @@ use log::warn;
 use lz4::Decoder as Lz4Decoder;
 use std::fmt::{self, Display};
 use std::fs::File;
-use std::io::{BufReader, Cursor, Read};
+use std::io::{BufReader, Cursor, Read, Seek};
 use std::str;
 use zstd::Decoder as ZstdDecoder;
 
@@ -162,10 +162,13 @@ pub fn decompress_data(
     };
     // transpose data
     if matches!(zip_type, 1 | 3 | 5) && zip_parameter > 0 {
-        // transpose
-        let m = org_data_length / zip_parameter as u64;
-        let tail: Vec<u8> = data.split_off((m * zip_parameter as u64) as usize);
-        let mut output = vec![0u8; (m * zip_parameter as u64) as usize];
+        // org_data_length comes from the file: clamp the transposed area to what
+        // was actually decompressed, otherwise split_off panics
+        let m =
+            (org_data_length / zip_parameter as u64).min(data.len() as u64 / zip_parameter as u64);
+        let transposed_len = (m * zip_parameter as u64) as usize;
+        let tail: Vec<u8> = data.split_off(transposed_len);
+        let mut output = vec![0u8; transposed_len];
         transpose::transpose(&data, &mut output, m as usize, zip_parameter as usize);
         data = output;
         if !tail.is_empty() {
@@ -175,11 +178,37 @@ pub fn decompress_data(
     Ok(data)
 }
 
+/// Number of bytes left between the current position and the end of the file.
+fn bytes_left(rdr: &mut BufReader<&File>) -> Result<u64> {
+    let file_size = rdr
+        .get_ref()
+        .metadata()
+        .context("Could not read file metadata")?
+        .len();
+    let position = rdr
+        .stream_position()
+        .context("Could not get stream position")?;
+    Ok(file_size.saturating_sub(position))
+}
+
+/// Checks a length field read from a DZ block against the bytes still in the file.
+fn validate_dz_data_length(block: &Dz4Block, rdr: &mut BufReader<&File>) -> Result<()> {
+    let available = bytes_left(rdr)?;
+    if block.dz_data_length > available {
+        bail!(
+            "DZ block declares {} compressed bytes but only {available} are left in the file",
+            block.dz_data_length
+        );
+    }
+    Ok(())
+}
+
 /// parses DZBlock
 pub fn parse_dz(rdr: &mut BufReader<&File>) -> Result<(Vec<u8>, Dz4Block)> {
     let mut block: Dz4Block = rdr
         .read_le()
         .context("Could not read into Dz4Block struct")?;
+    validate_dz_data_length(&block, rdr)?;
     let mut buf = vec![0u8; block.dz_data_length as usize];
     rdr.read_exact(&mut buf).context("Could not read Dz data")?;
     // decompress data
@@ -199,6 +228,7 @@ pub fn read_dz_raw(rdr: &mut BufReader<&File>) -> Result<(Dz4Block, Vec<u8>)> {
     let block: Dz4Block = rdr
         .read_le()
         .context("Could not read into Dz4Block struct")?;
+    validate_dz_data_length(&block, rdr)?;
     let mut buf = vec![0u8; block.dz_data_length as usize];
     rdr.read_exact(&mut buf)
         .context("Could not read Dz raw data")?;

--- a/src/mdfinfo/mdfinfo4/dg_block.rs
+++ b/src/mdfinfo/mdfinfo4/dg_block.rs
@@ -12,6 +12,7 @@ use std::io::{Cursor, Read};
 use super::block_header::{SharableBlocks, read_meta_data};
 use super::cg_block::{CG_F_VLSC, CG_F_VLSD, Cg4, parse_cg4};
 use super::metadata::BlockType;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::sym_buf_reader::SymBufReader;
 
 /// DGBLOCK structure (MDF 4.2 spec, Table 19)
@@ -140,7 +141,12 @@ pub fn parse_dg4(
         let dg_struct = Dg4 { block, cg };
         dg.insert(target, dg_struct);
         position = pos;
+        let mut chain = BlockChain::new("DG");
+        chain.visit(target);
         while next_pointer > 0 {
+            if !chain.visit(next_pointer) {
+                break;
+            }
             let block_start = next_pointer;
             let (block, pos) = parse_dg4_block(rdr, sharable, next_pointer, position)?;
             next_pointer = block.dg_dg_next;

--- a/src/mdfinfo/mdfinfo4/ev_block.rs
+++ b/src/mdfinfo/mdfinfo4/ev_block.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 
 use super::block_header::{SharableBlocks, parse_block_short, read_meta_data};
 use super::metadata::BlockType;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::sym_buf_reader::SymBufReader;
 
 /// Ev4 Event block struct
@@ -267,7 +268,12 @@ pub fn parse_ev4(
         let mut next_pointer = block.ev_ev_next;
         ev.insert(target, block);
 
+        let mut chain = BlockChain::new("EV");
+        chain.visit(target);
         while next_pointer > 0 {
+            if !chain.visit(next_pointer) {
+                break;
+            }
             let block_start = next_pointer;
             let (block, pos) = parse_ev4_block(rdr, next_pointer, position)?;
             position = pos;

--- a/src/mdfinfo/mdfinfo4/fh_block.rs
+++ b/src/mdfinfo/mdfinfo4/fh_block.rs
@@ -11,6 +11,7 @@ use std::io::{Cursor, Read};
 
 use super::block_header::{SharableBlocks, read_meta_data};
 use super::metadata::BlockType;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::sym_buf_reader::SymBufReader;
 
 /// FHBLOCK structure (MDF 4.2 spec, Table 18)
@@ -120,7 +121,12 @@ pub fn parse_fh(
         position = read_meta_data(rdr, sharable, block.fh_md_comment, position, BlockType::FH)?;
         let mut next_pointer = block.fh_fh_next;
         fh.push(block);
+        let mut chain = BlockChain::new("FH");
+        chain.visit(target);
         while next_pointer != 0 {
+            if !chain.visit(next_pointer) {
+                break;
+            }
             let (block, pos) = parse_fh_block(rdr, next_pointer, position)?;
             position = pos;
             next_pointer = block.fh_fh_next;

--- a/src/mdfreader/mdfreader4.rs
+++ b/src/mdfreader/mdfreader4.rs
@@ -1,6 +1,7 @@
 //! data read and load in memory based in MdfInfo4's metadata
 use crate::data_holder::channel_data::ChannelData;
 use crate::mdfinfo::MdfInfo;
+use crate::mdfinfo::block_chain::BlockChain;
 use crate::mdfinfo::mdfinfo4::{Blockheader4, Cg4, Cn4, Composition, Dg4, Ds4Block};
 use crate::mdfinfo::mdfinfo4::{
     CG_F_VLSC, CG_F_VLSD, Dl4Block, Dt4Block, Dz4Block, Gd4Block, Hl4Block, Ld4Block, parse_dz,
@@ -670,11 +671,16 @@ fn parser_ld4(
     channel_group: &mut Cg4,
 ) -> Result<i64> {
     let mut ld_blocks: Vec<Ld4Block> = Vec::new();
+    let mut chain = BlockChain::new("LD");
+    chain.visit(position);
     let (block, pos) = parser_ld4_block(rdr, position, position)?;
     position = pos;
     ld_blocks.push(block.clone());
     let mut next_ld = block.ld_ld_next();
     while next_ld > 0 {
+        if !chain.visit(next_ld) {
+            break;
+        }
         rdr.seek_relative(next_ld - position)
             .context("Could not reach LD block position")?;
         position = next_ld;
@@ -905,16 +911,14 @@ fn read_dv_di(
 /// Reads all DL Blocks and returns a vect of them
 fn parser_dl4(rdr: &mut BufReader<&File>, mut position: i64) -> Result<(Vec<Dl4Block>, i64)> {
     let mut dl_blocks: Vec<Dl4Block> = Vec::new();
-    let mut visited: HashSet<i64> = HashSet::new();
-    let start = position;
-    visited.insert(start);
+    let mut chain = BlockChain::new("DL");
+    chain.visit(position);
     let (block, pos) = parser_dl4_block(rdr, position, position)?;
     position = pos;
     dl_blocks.push(block.clone());
     let mut next_dl = block.dl_dl_next;
     while next_dl > 0 {
-        if !visited.insert(next_dl) {
-            warn!("DL block cycle detected at 0x{next_dl:x}, stopping chain walk");
+        if !chain.visit(next_dl) {
             break;
         }
         rdr.seek_relative(next_dl - position)

--- a/tests/malformed.rs
+++ b/tests/malformed.rs
@@ -1,0 +1,693 @@
+/// Malformed MDF fixture builder and regression tests.
+///
+/// Every file here is built in memory, written to a temporary directory and read
+/// back through the public `MdfInfo::new` entry point. The fixtures exercise two
+/// classes of corrupted structural fields:
+///  - block chain links that loop back on themselves,
+///  - size fields that claim more bytes than the file holds.
+use mdfr::mdfinfo::MdfInfo;
+use tempfile::TempDir;
+
+// ─── Low-level byte helpers ──────────────────────────────────────────────────
+
+fn push_u8(buf: &mut Vec<u8>, v: u8) {
+    buf.push(v);
+}
+fn push_u16(buf: &mut Vec<u8>, v: u16) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+fn push_i16(buf: &mut Vec<u8>, v: i16) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+fn push_u32(buf: &mut Vec<u8>, v: u32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+fn push_u64(buf: &mut Vec<u8>, v: u64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+fn push_i64(buf: &mut Vec<u8>, v: i64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+fn push_f64(buf: &mut Vec<u8>, v: f64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+fn push_zeros(buf: &mut Vec<u8>, n: usize) {
+    buf.extend(std::iter::repeat_n(0u8, n));
+}
+
+/// Writes `bytes` into a temporary directory and returns the directory plus path.
+fn write_tmp(name: &str, bytes: &[u8]) -> (TempDir, String) {
+    let dir = TempDir::new().expect("could not create temp dir");
+    let path = dir.path().join(name);
+    std::fs::write(&path, bytes).expect("could not write fixture");
+    let path = path.to_string_lossy().into_owned();
+    (dir, path)
+}
+
+// ─── MDF4 block writers ──────────────────────────────────────────────────────
+
+const ID: usize = 64;
+const HD: usize = 104;
+/// Offset of the first block after the ID and HD blocks.
+const B0: i64 = (ID + HD) as i64;
+/// Offset of the attachment in the valid MDF4 fixture, right after the FH block.
+const B0_AT: i64 = B0 + 56;
+
+fn write_id4(buf: &mut Vec<u8>) {
+    buf.extend_from_slice(b"MDF     ");
+    buf.extend_from_slice(b"4.10    ");
+    buf.extend_from_slice(b"mdfr    ");
+    push_u16(buf, 0); // id_default_byteorder
+    push_u16(buf, 0); // id_floatingpointformat
+    push_u16(buf, 410); // id_ver
+    push_u16(buf, 0); // id_codepage
+    push_zeros(buf, 2); // id_check
+    push_zeros(buf, 26); // id_fill
+    push_u16(buf, 0); // id_unfin_flags
+    push_u16(buf, 0); // id_custom_unfin_flags
+}
+
+#[derive(Default)]
+struct Hd4Links {
+    dg_first: i64,
+    fh_first: i64,
+    ch_first: i64,
+    at_first: i64,
+    ev_first: i64,
+}
+
+fn write_hd4(buf: &mut Vec<u8>, links: &Hd4Links) {
+    buf.extend_from_slice(b"##HD");
+    push_zeros(buf, 4);
+    push_u64(buf, HD as u64);
+    push_u64(buf, 6);
+    push_i64(buf, links.dg_first);
+    push_i64(buf, links.fh_first);
+    push_i64(buf, links.ch_first);
+    push_i64(buf, links.at_first);
+    push_i64(buf, links.ev_first);
+    push_i64(buf, 0); // hd_md_comment
+    push_u64(buf, 0); // hd_start_time_ns
+    push_i16(buf, 0);
+    push_i16(buf, 0);
+    push_u8(buf, 0);
+    push_u8(buf, 0);
+    push_u8(buf, 0);
+    push_u8(buf, 0);
+    push_f64(buf, 0.0);
+    push_f64(buf, 0.0);
+}
+
+/// FHBLOCK, 56 bytes.
+fn write_fh(buf: &mut Vec<u8>, fh_next: i64) {
+    buf.extend_from_slice(b"##FH");
+    push_zeros(buf, 4);
+    push_u64(buf, 56);
+    push_u64(buf, 2);
+    push_i64(buf, fh_next);
+    push_i64(buf, 0); // fh_md_comment
+    push_u64(buf, 0); // fh_time_ns
+    push_i16(buf, 0);
+    push_i16(buf, 0);
+    push_u8(buf, 0);
+    push_zeros(buf, 3);
+}
+
+/// DGBLOCK, 64 bytes.
+fn write_dg4(buf: &mut Vec<u8>, dg_next: i64, cg_first: i64) {
+    buf.extend_from_slice(b"##DG");
+    push_zeros(buf, 4);
+    push_u64(buf, 64);
+    push_u64(buf, 4);
+    push_i64(buf, dg_next);
+    push_i64(buf, cg_first);
+    push_i64(buf, 0); // dg_data
+    push_i64(buf, 0); // dg_md_comment
+    push_u8(buf, 0); // dg_rec_id_size
+    push_zeros(buf, 7);
+}
+
+/// CGBLOCK, 104 bytes (6 links, no cg_cg_master).
+fn write_cg4(buf: &mut Vec<u8>, cg_next: i64, cn_first: i64, sr_first: i64) {
+    buf.extend_from_slice(b"##CG");
+    push_zeros(buf, 4);
+    push_u64(buf, 104);
+    push_u64(buf, 6);
+    push_i64(buf, cg_next);
+    push_i64(buf, cn_first);
+    push_i64(buf, 0); // cg_tx_acq_name
+    push_i64(buf, 0); // cg_si_acq_source
+    push_i64(buf, sr_first);
+    push_i64(buf, 0); // cg_md_comment
+    push_u64(buf, 0); // cg_record_id
+    push_u64(buf, 0); // cg_cycle_count
+    push_u16(buf, 0); // cg_flags
+    push_u16(buf, 0); // cg_path_separator
+    push_zeros(buf, 4);
+    push_u32(buf, 0); // cg_data_bytes
+    push_u32(buf, 0); // cg_inval_bytes
+}
+
+/// CNBLOCK, 160 bytes (8 links).
+fn write_cn4(buf: &mut Vec<u8>, cn_next: i64) {
+    buf.extend_from_slice(b"##CN");
+    push_zeros(buf, 4);
+    push_u64(buf, 160);
+    push_u64(buf, 8);
+    push_i64(buf, cn_next);
+    push_zeros(buf, 7 * 8); // composition, tx_name, si_source, cc_conversion, data, md_unit, md_comment
+    push_u8(buf, 2); // cn_type = master
+    push_u8(buf, 1); // cn_sync_type = time
+    push_u8(buf, 4); // cn_data_type = FloatLE
+    push_u8(buf, 0); // cn_bit_offset
+    push_u32(buf, 0); // cn_byte_offset
+    push_u32(buf, 64); // cn_bit_count
+    push_u32(buf, 0); // cn_flags
+    push_u32(buf, 0); // cn_inval_bit_pos
+    push_u8(buf, 0xff); // cn_precision
+    push_u8(buf, 0); // cn_alignment
+    push_u16(buf, 0); // cn_attachment_count
+    push_zeros(buf, 6 * 8); // val ranges and limits
+}
+
+/// ATBLOCK, 96 bytes plus `trailing` embedded bytes.
+fn write_at4(buf: &mut Vec<u8>, at_next: i64, flags: u16, embedded_size: u64, trailing: &[u8]) {
+    buf.extend_from_slice(b"##AT");
+    push_zeros(buf, 4);
+    push_u64(buf, 96);
+    push_u64(buf, 4);
+    push_i64(buf, at_next);
+    push_i64(buf, 0); // at_tx_filename
+    push_i64(buf, 0); // at_tx_mimetype
+    push_i64(buf, 0); // at_md_comment
+    push_u16(buf, flags);
+    push_u16(buf, 0); // at_creator_index
+    push_u8(buf, 0); // at_zip_type
+    push_u8(buf, 0); // at_path_syntax
+    push_zeros(buf, 2);
+    push_zeros(buf, 16); // at_md5_checksum
+    push_u64(buf, embedded_size); // at_original_size
+    push_u64(buf, embedded_size); // at_embedded_size
+    buf.extend_from_slice(trailing);
+}
+
+/// EVBLOCK, 96 bytes (5 links).
+fn write_ev4(buf: &mut Vec<u8>, ev_next: i64) {
+    buf.extend_from_slice(b"##EV");
+    push_zeros(buf, 4);
+    push_u64(buf, 96);
+    push_u64(buf, 5); // ev_links
+    push_i64(buf, ev_next);
+    push_i64(buf, 0); // ev_ev_parent
+    push_i64(buf, 0); // ev_ev_range
+    push_i64(buf, 0); // ev_tx_name
+    push_i64(buf, 0); // ev_md_comment
+    push_u8(buf, 4); // ev_type = marker
+    push_u8(buf, 1); // ev_sync_type = time
+    push_u8(buf, 0); // ev_range_type
+    push_u8(buf, 0); // ev_cause
+    push_u8(buf, 0); // ev_flags
+    push_zeros(buf, 3);
+    push_u32(buf, 0); // ev_scope_count
+    push_u16(buf, 0); // ev_attachment_count
+    push_u16(buf, 0); // ev_creator_index
+    push_i64(buf, 0); // ev_sync_base_value
+    push_f64(buf, 0.0); // ev_sync_factor
+}
+
+/// CHBLOCK, 64 bytes (4 links, no elements).
+fn write_ch4(buf: &mut Vec<u8>, ch_next: i64, ch_first: i64) {
+    buf.extend_from_slice(b"##CH");
+    push_zeros(buf, 4);
+    push_u64(buf, 64);
+    push_u64(buf, 4); // ch_links
+    push_i64(buf, ch_next);
+    push_i64(buf, ch_first);
+    push_i64(buf, 0); // ch_tx_name
+    push_i64(buf, 0); // ch_md_comment
+    push_u32(buf, 0); // ch_element_count
+    push_u8(buf, 0); // ch_type
+    push_zeros(buf, 3);
+}
+
+/// SRBLOCK, 56 bytes. `len` overrides the declared block length.
+fn write_sr4(buf: &mut Vec<u8>, sr_next: i64, len: u64) {
+    buf.extend_from_slice(b"##SR");
+    push_zeros(buf, 4);
+    push_u64(buf, len);
+    push_i64(buf, sr_next);
+    push_i64(buf, 0); // sr_data
+    push_u64(buf, 0); // sr_cycle_count
+    push_f64(buf, 0.0); // sr_interval
+    push_u8(buf, 1); // sr_sync_type
+    push_u8(buf, 0); // sr_flags
+    push_zeros(buf, 6);
+}
+
+// ─── MDF3 block writers ──────────────────────────────────────────────────────
+
+fn write_id3(buf: &mut Vec<u8>) {
+    buf.extend_from_slice(b"MDF     ");
+    buf.extend_from_slice(b"3.30    ");
+    buf.extend_from_slice(b"mdfr    ");
+    push_u16(buf, 0); // id_default_byteorder
+    push_u16(buf, 0); // id_floatingpointformat
+    push_u16(buf, 330); // id_ver
+    push_u16(buf, 0); // id_codepage
+    push_zeros(buf, 2);
+    push_zeros(buf, 26);
+    push_u16(buf, 0);
+    push_u16(buf, 0);
+}
+
+/// TXBLOCK of MDF3, 8 bytes (4 byte header plus "ok\0\0").
+fn write_tx3(buf: &mut Vec<u8>) {
+    buf.extend_from_slice(b"TX");
+    push_u16(buf, 8);
+    buf.extend_from_slice(b"ok\0\0");
+}
+
+/// HDBLOCK of MDF3, 208 bytes including the 3.2 extension.
+fn write_hd3(buf: &mut Vec<u8>, dg_first: u32, md_comment: u32) {
+    buf.extend_from_slice(b"HD");
+    push_u16(buf, 208); // hd_len
+    push_u32(buf, dg_first);
+    push_u32(buf, md_comment); // hd_md_comment
+    push_u32(buf, 0); // hd_pr
+    push_u16(buf, 1); // hd_n_datagroups
+    buf.extend_from_slice(b"01:01:2024"); // hd_date
+    buf.extend_from_slice(b"00:00:00"); // hd_time
+    push_zeros(buf, 32); // hd_author
+    push_zeros(buf, 32); // hd_organization
+    push_zeros(buf, 32); // hd_project
+    push_zeros(buf, 32); // hd_subject
+    // 3.2 extension
+    push_u64(buf, 0); // hd_start_time_ns
+    push_i16(buf, 0); // hd_time_offset
+    push_u16(buf, 0); // hd_time_quality
+    push_zeros(buf, 32); // hd_time_identifier
+}
+
+/// Offset of the first block after the MDF3 ID and HD blocks.
+const B0_MDF3: u32 = (ID + 208) as u32;
+
+/// DGBLOCK of MDF3, 24 bytes.
+fn write_dg3(buf: &mut Vec<u8>, dg_next: u32, cg_first: u32, n_cg: u16) {
+    buf.extend_from_slice(b"DG");
+    push_u16(buf, 24); // dg_len
+    push_u32(buf, dg_next);
+    push_u32(buf, cg_first);
+    push_u32(buf, 0); // dg_tr
+    push_u32(buf, 0); // dg_data
+    push_u16(buf, n_cg); // dg_n_cg
+    push_u16(buf, 0); // dg_n_record_ids
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/// Valid MDF4 file: one FH block terminating the chain, one embedded attachment
+/// whose declared size matches the bytes that follow it.
+fn good_mdf4() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            fh_first: B0,
+            at_first: B0 + 56,
+            ..Default::default()
+        },
+    );
+    write_fh(&mut buf, 0);
+    write_at4(&mut buf, 0, 0b1, 8, b"ABCDEFGH");
+    buf
+}
+
+/// One MDF4 file per chain type, with the head block's `*_next` link pointing at
+/// itself. Returns (name, bytes) pairs.
+fn self_referencing_mdf4_chains() -> Vec<(&'static str, Vec<u8>)> {
+    let mut out: Vec<(&'static str, Vec<u8>)> = Vec::new();
+
+    // FH chain
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            fh_first: B0,
+            ..Default::default()
+        },
+    );
+    write_fh(&mut buf, B0);
+    out.push(("fh_self_cycle.mf4", buf));
+
+    // DG chain
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            dg_first: B0,
+            ..Default::default()
+        },
+    );
+    write_dg4(&mut buf, B0, 0);
+    out.push(("dg_self_cycle.mf4", buf));
+
+    // AT chain
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            at_first: B0,
+            ..Default::default()
+        },
+    );
+    write_at4(&mut buf, B0, 0, 0, &[]);
+    out.push(("at_self_cycle.mf4", buf));
+
+    // EV chain
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            ev_first: B0,
+            ..Default::default()
+        },
+    );
+    write_ev4(&mut buf, B0);
+    out.push(("ev_self_cycle.mf4", buf));
+
+    // CH chain, sibling link
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            ch_first: B0,
+            ..Default::default()
+        },
+    );
+    write_ch4(&mut buf, B0, 0);
+    out.push(("ch_self_cycle.mf4", buf));
+
+    // CG chain, reached through a DG block
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            dg_first: B0,
+            ..Default::default()
+        },
+    );
+    write_dg4(&mut buf, 0, B0 + 64);
+    write_cg4(&mut buf, B0 + 64, 0, 0);
+    out.push(("cg_self_cycle.mf4", buf));
+
+    // CN chain, reached through DG → CG
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            dg_first: B0,
+            ..Default::default()
+        },
+    );
+    write_dg4(&mut buf, 0, B0 + 64);
+    write_cg4(&mut buf, 0, B0 + 64 + 104, 0);
+    write_cn4(&mut buf, B0 + 64 + 104);
+    out.push(("cn_self_cycle.mf4", buf));
+
+    // SR chain, reached through DG → CG
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            dg_first: B0,
+            ..Default::default()
+        },
+    );
+    write_dg4(&mut buf, 0, B0 + 64);
+    write_cg4(&mut buf, 0, 0, B0 + 64 + 104);
+    write_sr4(&mut buf, B0 + 64 + 104, 56);
+    out.push(("sr_self_cycle.mf4", buf));
+
+    out
+}
+
+/// MDF4 file with a CH block whose child link points back at itself, so the
+/// recursive descent never bottoms out.
+fn ch_self_child() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            ch_first: B0,
+            ..Default::default()
+        },
+    );
+    write_ch4(&mut buf, 0, B0);
+    buf
+}
+
+/// MDF3 file whose DG block links to itself.
+fn mdf3_dg_self_cycle() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id3(&mut buf);
+    write_hd3(&mut buf, B0_MDF3 + 8, B0_MDF3);
+    write_tx3(&mut buf);
+    write_dg3(&mut buf, B0_MDF3 + 8, 0, 0);
+    buf
+}
+
+/// Valid MDF3 file: DG chain terminates.
+fn good_mdf3() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id3(&mut buf);
+    write_hd3(&mut buf, B0_MDF3 + 8, B0_MDF3);
+    write_tx3(&mut buf);
+    write_dg3(&mut buf, 0, 0, 1);
+    buf
+}
+
+/// MDF4 file whose attachment declares an embedded size of u64::MAX.
+fn at_embedded_size_overflow() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            at_first: B0,
+            ..Default::default()
+        },
+    );
+    write_at4(&mut buf, 0, 0b1, u64::MAX, &[]);
+    buf
+}
+
+/// MDF4 file whose attachment declares an embedded size far beyond the file end
+/// but small enough to allocate.
+fn at_embedded_size_beyond_eof() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            at_first: B0,
+            ..Default::default()
+        },
+    );
+    write_at4(&mut buf, 0, 0b1, 1 << 34, &[]);
+    buf
+}
+
+/// MDF4 file whose SR block declares a length below the 16 byte short header.
+fn sr_undersized_len() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            dg_first: B0,
+            ..Default::default()
+        },
+    );
+    write_dg4(&mut buf, 0, B0 + 64);
+    write_cg4(&mut buf, 0, 0, B0 + 64 + 104);
+    write_sr4(&mut buf, 0, 0);
+    buf
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn valid_files_still_parse() {
+    let (_dir, path) = write_tmp("good.mf4", &good_mdf4());
+    let info = MdfInfo::new(&path).expect("valid MDF4 file must parse");
+    assert_eq!(info.get_version(), 410);
+    match info {
+        MdfInfo::V4(info) => {
+            assert_eq!(info.fh.len(), 1);
+            let (block, data) = info.at.get(&B0_AT).expect("attachment must be read");
+            assert_eq!(block.at_embedded_size, 8);
+            // the size check must not disturb the single exact-size allocation
+            let data = data.as_ref().expect("embedded data must be read");
+            assert_eq!(data.as_slice(), b"ABCDEFGH");
+            assert_eq!(data.capacity(), 8);
+        }
+        MdfInfo::V3(_) => panic!("expected an MDF4 file"),
+    }
+
+    let (_dir, path) = write_tmp("good.mdf", &good_mdf3());
+    let info = MdfInfo::new(&path).expect("valid MDF3 file must parse");
+    assert_eq!(info.get_version(), 330);
+    match info {
+        MdfInfo::V3(info) => assert_eq!(info.dg.len(), 1),
+        MdfInfo::V4(_) => panic!("expected an MDF3 file"),
+    }
+}
+
+#[test]
+fn self_referencing_chains_terminate() {
+    // Each of these hangs the parser without the cycle guard.
+    for (name, bytes) in self_referencing_mdf4_chains() {
+        let (_dir, path) = write_tmp(name, &bytes);
+        let info = MdfInfo::new(&path)
+            .unwrap_or_else(|e| panic!("{name} should read as a truncated chain, got {e:#}"));
+        match info {
+            MdfInfo::V4(info) => {
+                // the head block is kept, the repeated link is not followed
+                assert!(info.fh.len() <= 1, "{name}: FH chain not truncated");
+                assert!(info.at.len() <= 1, "{name}: AT chain not truncated");
+                assert!(info.ev.len() <= 1, "{name}: EV chain not truncated");
+                assert!(info.ch.len() <= 1, "{name}: CH chain not truncated");
+                assert!(info.dg.len() <= 1, "{name}: DG chain not truncated");
+                for dg in info.dg.values() {
+                    assert!(dg.cg.len() <= 1, "{name}: CG chain not truncated");
+                    for cg in dg.cg.values() {
+                        assert!(cg.cn.len() <= 1, "{name}: CN chain not truncated");
+                        assert!(cg.sr.len() <= 1, "{name}: SR chain not truncated");
+                    }
+                }
+            }
+            MdfInfo::V3(_) => panic!("{name}: expected an MDF4 file"),
+        }
+    }
+
+    let (_dir, path) = write_tmp("dg_self_cycle.mdf", &mdf3_dg_self_cycle());
+    let info = MdfInfo::new(&path).expect("MDF3 DG cycle should read as a truncated chain");
+    match info {
+        MdfInfo::V3(info) => assert_eq!(info.dg.len(), 1),
+        MdfInfo::V4(_) => panic!("expected an MDF3 file"),
+    }
+}
+
+#[test]
+fn ch_child_cycle_terminates() {
+    // Without the guard the recursive descent overflows the stack.
+    let (_dir, path) = write_tmp("ch_self_child.mf4", &ch_self_child());
+    let info = MdfInfo::new(&path).expect("CH child cycle should read as a truncated tree");
+    match info {
+        MdfInfo::V4(info) => assert_eq!(info.ch.len(), 1),
+        MdfInfo::V3(_) => panic!("expected an MDF4 file"),
+    }
+}
+
+#[test]
+fn oversized_attachment_is_rejected() {
+    let (_dir, path) = write_tmp("at_overflow.mf4", &at_embedded_size_overflow());
+    assert!(
+        MdfInfo::new(&path).is_err(),
+        "attachment claiming u64::MAX embedded bytes must be rejected"
+    );
+
+    let (_dir, path) = write_tmp("at_beyond_eof.mf4", &at_embedded_size_beyond_eof());
+    assert!(
+        MdfInfo::new(&path).is_err(),
+        "attachment claiming more bytes than the file holds must be rejected"
+    );
+}
+
+#[test]
+fn undersized_sr_block_is_rejected() {
+    let (_dir, path) = write_tmp("sr_short.mf4", &sr_undersized_len());
+    assert!(
+        MdfInfo::new(&path).is_err(),
+        "SR block shorter than its own header must be rejected"
+    );
+}
+
+/// TXBLOCK of MDF3 with an overridden block length.
+fn write_tx3_len(buf: &mut Vec<u8>, len: u16) {
+    buf.extend_from_slice(b"TX");
+    push_u16(buf, len);
+    buf.extend_from_slice(b"ok\0\0");
+}
+
+/// MDF3 file whose HD comment points at a TX block shorter than its own header.
+fn mdf3_tx_undersized() -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id3(&mut buf);
+    write_hd3(&mut buf, B0_MDF3 + 8, B0_MDF3);
+    write_tx3_len(&mut buf, 0);
+    write_dg3(&mut buf, 0, 0, 1);
+    buf
+}
+
+/// CHBLOCK with an overridden link count.
+fn write_ch4_links(buf: &mut Vec<u8>, ch_links: u64) {
+    buf.extend_from_slice(b"##CH");
+    push_zeros(buf, 4);
+    push_u64(buf, 64);
+    push_u64(buf, ch_links);
+    push_i64(buf, 0); // ch_ch_next
+    push_i64(buf, 0); // ch_ch_first
+    push_i64(buf, 0); // ch_tx_name
+    push_i64(buf, 0); // ch_md_comment
+    push_u32(buf, 0); // ch_element_count
+    push_u8(buf, 0); // ch_type
+    push_zeros(buf, 3);
+}
+
+/// MDF4 file whose CH block declares `ch_links` links in a 64 byte block.
+fn ch_bad_link_count(ch_links: u64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_id4(&mut buf);
+    write_hd4(
+        &mut buf,
+        &Hd4Links {
+            ch_first: B0,
+            ..Default::default()
+        },
+    );
+    write_ch4_links(&mut buf, ch_links);
+    buf
+}
+
+#[test]
+fn undersized_mdf3_tx_block_is_rejected() {
+    let (_dir, path) = write_tmp("tx_short.mdf", &mdf3_tx_undersized());
+    assert!(
+        MdfInfo::new(&path).is_err(),
+        "TX block shorter than its own header must be rejected"
+    );
+}
+
+#[test]
+fn implausible_ch_link_count_is_rejected() {
+    // 0 and 3 underflow the ch_element count, the large values would size the
+    // vector far beyond the 64 byte block
+    for ch_links in [0u64, 3, 1 << 40, u64::MAX] {
+        let (_dir, path) = write_tmp("ch_links.mf4", &ch_bad_link_count(ch_links));
+        assert!(
+            MdfInfo::new(&path).is_err(),
+            "CH block declaring {ch_links} links in a 64 byte block must be rejected"
+        );
+    }
+}


### PR DESCRIPTION
Two shapes of corrupted structural field make `MdfInfo::new` hang or abort on files of a few hundred bytes.

**Block chains are walked with no memory of where they have been**, so a `*_next` link pointing back into its own chain is followed forever. I checked all 11 walks under `src/mdfinfo/` plus `parser_ld4` with an in-loop iteration counter: 2,000,000 iterations with `next_pointer` never changing. `parse_ch4` recurses on `ch_ch_first` instead, so a child link pointing at its parent overflows the stack and aborts. `parser_dl4` already had a visited set for exactly this — I extracted it as `BlockChain` and used it in the other 12 walks.

**Size and count fields are used as-is to size a buffer.** `at_embedded_size = u64::MAX` panics with `capacity overflow`; an SR block or MDF3 TX block declaring a length below its own header underflows the `- 16` / `- 4`; `dz_org_data_length` makes `split_off` index past the decompressed data; `ch_links` sizes `ch_element` unchecked. All are now checked against the bytes left in the file or the block, the way `validate_len` already does for the generic header.

`tests/malformed.rs` builds each corrupted file in memory and reads it back through `MdfInfo::new`, with valid MDF3/MDF4 controls. `cargo test --no-default-features --features parquet` matches main apart from the new tests; fmt and `clippy --lib -- -D warnings` clean.

The `cg_cycle_count`-sized record buffers and the `len - 24` reads in the data-reading path have the same shape, but fixing them needs the record count cross-checked against the data block, so I left those out.
